### PR TITLE
sec: Mitigate the attack surface of potential malicious injection

### DIFF
--- a/src/Services/Routes.php
+++ b/src/Services/Routes.php
@@ -107,7 +107,7 @@ class Routes implements ArrayAccess
             return $this->routes[$path];
         }
 
-        throw new InvalidArgumentException("Route $path not found.");
+        throw new InvalidArgumentException('Route not found.');
     }
 
     /**


### PR DESCRIPTION
Simplify error message for route not found

- This change attempts to leave less room to potential attacks possible when double quotes are use without prior sanitize or type enforcement.
- By using plain text with single quote we mitigate the issue.